### PR TITLE
Enable data input schema validation

### DIFF
--- a/workflows/ansible-job-template.sw.yaml
+++ b/workflows/ansible-job-template.sw.yaml
@@ -34,13 +34,13 @@ states:
                 url: >-
                   https://github.com/janus-idp/software-templates/tree/main/templates/github/launch-ansible-job/skeleton
                 values:
-                  name: ${.name}
-                  jobTemplate: ${.jobTemplate}
-                  component_id: ${.name}
-                  namespace: ${.namespace}
-                  connection_secret: ${.connectionSecret}
-                  description: ${.description}
-                  extra_vars: ${.extraVars}
+                  name: ${.ansibleJobDefinition.name}
+                  jobTemplate: ${.ansibleJobDefinition.jobTemplate}
+                  component_id: ${.ansibleJobDefinition.name}
+                  namespace: ${.ansibleJobDefinition.namespace}
+                  connection_secret: ${.ansibleJobDefinition.connectionSecret}
+                  description: ${.ansibleJobDefinition.description}
+                  extra_vars: ${.ansibleJobDefinition.extraVars}
       - name: Generating the Catalog Info Component
         actions:
           - functionRef:
@@ -50,11 +50,11 @@ states:
                 url: >-
                   https://github.com/janus-idp/software-templates/tree/main/skeletons/catalog-info
                 values:
-                  githubOrg: ${.githubOrg}
-                  repoName: ${.repoName}
-                  owner: ${.owner}
+                  githubOrg: ${.repositoryInfo.githubOrg}
+                  repoName: ${.repositoryInfo.repoName}
+                  owner: ${.repositoryInfo.owner}
                   applicationType: api
-                  description: ${.description}
+                  description: ${.ansibleJobDefinition.description}
     onErrors:
       - errorRef: Error on Action
         transition: Handle Error
@@ -69,9 +69,9 @@ states:
           refName: runActionGitHubRepoPush
           arguments:
             id: $WORKFLOW.instanceId
-            title: '.name + "-job"'
+            title: '.ansibleJobDefinition.name + "-job"'
             description: Workflow Action
-            repoUrl: '"github.com?owner=" + .githubOrg + "&repo=" + .repoName'
+            repoUrl: '"github.com?owner=" + .repositoryInfo.githubOrg + "&repo=" + .repositoryInfo.repoName'
             defaultBranch: main
             gitCommitMessage: Initial commit
             protectDefaultBranch: false

--- a/workflows/go-backend.sw.yaml
+++ b/workflows/go-backend.sw.yaml
@@ -32,15 +32,15 @@ states:
             url: >-
               https://github.com/janus-idp/software-templates/tree/main/templates/github/go-backend/skeleton
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
         actionDataFilter:
           toStateData: .actionFetchTemplateSourceCodeResult
@@ -52,9 +52,9 @@ states:
   - name: Generating the CI Component
     type: switch
     dataConditions:
-      - condition: ${ .ci == "github" }
+      - condition: ${ .ciMethod.ci == "github" }
         transition: Generating the CI Component - GitHub
-      - condition: ${ .ci == "tekton" }
+      - condition: ${ .ciMethod.ci == "tekton" }
         transition: Generating the CI Component - Tekton
     defaultCondition:
       transition: Generating the CI Component - GitHub
@@ -71,15 +71,15 @@ states:
             copyWithoutTemplating:
               - '".github/workflows/"'
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
         actionDataFilter:
           toStateData: .actionTemplateFetchCIResult
@@ -101,18 +101,18 @@ states:
             copyWithoutTemplating:
               - '".github/workflows/"'
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              imageUrl: .imageUrl
-              imageRepository: .imageRepository
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              imageUrl: .ciMethod.imageUrl
+              imageRepository: .ciMethod.imageRepository
               imageBuilder: s2i-go
-              port: .port
-              ci: .ci
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
         actionDataFilter:
           toStateData: .actionTemplateFetchCIResult
@@ -131,18 +131,18 @@ states:
             url: >-
               https://github.com/janus-idp/software-templates/tree/main/skeletons/catalog-info
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              imageUrl: imageUrl
-              imageRepository: .imageRepository
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              imageUrl: .ciMethod.imageUrl
+              imageRepository: .ciMethod.imageRepository
               imageBuilder: s2i-go
-              port: .port
-              ci: .ci
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
         actionDataFilter:
           toStateData: .actionFetchTemplateCatalogInfoResult
@@ -162,7 +162,7 @@ states:
             allowedHosts:
               - '"github.com"'
             description: Workflow Action
-            repoUrl: '"github.com?owner=" + .orgName + "&repo=" + .repoName'
+            repoUrl: '"github.com?owner=" + .newComponent.orgName + "&repo=" + .newComponent.repoName'
             defaultBranch: main
             gitCommitMessage: Initial commit
             allowAutoMerge: true

--- a/workflows/nodejs-backend.sw.yaml
+++ b/workflows/nodejs-backend.sw.yaml
@@ -32,15 +32,15 @@ states:
             url: >-
               https://github.com/janus-idp/software-templates/tree/main/templates/github/nodejs-backend/skeleton
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
         actionDataFilter:
           toStateData: .actionFetchTemplateSourceCodeResult
@@ -52,9 +52,9 @@ states:
   - name: Generating the CI Component
     type: switch
     dataConditions:
-      - condition: ${ .ci == "github" }
+      - condition: ${ .ciMethod.ci == "github" }
         transition: Generating the CI Component - GitHub
-      - condition: ${ .ci == "tekton" }
+      - condition: ${ .ciMethod.ci == "tekton" }
         transition: Generating the CI Component - Tekton
     defaultCondition:
       transition: Generating the CI Component - GitHub
@@ -71,15 +71,15 @@ states:
             copyWithoutTemplating:
               - '".github/workflows/"'
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
         actionDataFilter:
           toStateData: .actionTemplateFetchCIResult
@@ -101,18 +101,18 @@ states:
             copyWithoutTemplating:
               - '".github/workflows/"'
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              imageUrl: .imageUrl
-              imageRepository: .imageRepository
-              imageBuilder: s2i-nodejs
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              imageUrl: .ciMethod.imageUrl
+              imageRepository: .ciMethod.imageRepository
+              imageBuilder: s2i-go
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
         actionDataFilter:
           toStateData: .actionTemplateFetchCIResult
@@ -131,18 +131,18 @@ states:
             url: >-
               https://github.com/janus-idp/software-templates/tree/main/skeletons/catalog-info
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              imageUrl: imageUrl
-              imageRepository: .imageRepository
-              imageBuilder: s2i-nodejs
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              imageUrl: .ciMethod.imageUrl
+              imageRepository: .ciMethod.imageRepository
+              imageBuilder: s2i-go
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
         actionDataFilter:
           toStateData: .actionFetchTemplateCatalogInfoResult
@@ -162,7 +162,7 @@ states:
             allowedHosts:
               - '"github.com"'
             description: Workflow Action
-            repoUrl: '"github.com?owner=" + .orgName + "&repo=" + .repoName'
+            repoUrl: '"github.com?owner=" + .newComponent.orgName + "&repo=" + .newComponent.repoName'
             defaultBranch: main
             gitCommitMessage: Initial commit
             allowAutoMerge: true

--- a/workflows/quarkus-backend.sw.yaml
+++ b/workflows/quarkus-backend.sw.yaml
@@ -32,20 +32,20 @@ states:
             url: >-
               https://github.com/janus-idp/software-templates/tree/main/templates/github/quarkus-backend/skeleton
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
-              groupId: .groupId
-              artifactId: .artifactId
-              javaPackageName: .javaPackageName
-              version: .version
+              groupId: .javaMetadata.groupId
+              artifactId: .javaMetadata.artifactId
+              javaPackageName: .javaMetadata.javaPackageName
+              version: .javaMetadata.version
         actionDataFilter:
           toStateData: .actionFetchTemplateSourceCodeResult
     onErrors:
@@ -56,9 +56,9 @@ states:
   - name: Generating the CI Component
     type: switch
     dataConditions:
-      - condition: ${ .ci == "github" }
+      - condition: ${ .ciMethod.ci == "github" }
         transition: Generating the CI Component - GitHub
-      - condition: ${ .ci == "tekton" }
+      - condition: ${ .ciMethod.ci == "tekton" }
         transition: Generating the CI Component - Tekton
     defaultCondition:
       transition: Generating the CI Component - GitHub
@@ -75,20 +75,20 @@ states:
             copyWithoutTemplating:
               - '".github/workflows/"'
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
-              groupId: .groupId
-              artifactId: .artifactId
-              javaPackageName: .javaPackageName
-              version: .version
+              groupId: .javaMetadata.groupId
+              artifactId: .javaMetadata.artifactId
+              javaPackageName: .javaMetadata.javaPackageName
+              version: .javaMetadata.version
         actionDataFilter:
           toStateData: .actionTemplateFetchCIResult
     onErrors:
@@ -109,23 +109,23 @@ states:
             copyWithoutTemplating:
               - '".github/workflows/"'
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
               imageUrl: .imageUrl
               imageRepository: .imageRepository
-              imageBuilder: s2i-java
-              port: .port
-              ci: .ci
+              imageBuilder: s2i-go
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
-              groupId: .groupId
-              artifactId: .artifactId
-              javaPackageName: .javaPackageName
-              version: .version
+              groupId: .javaMetadata.groupId
+              artifactId: .javaMetadata.artifactId
+              javaPackageName: .javaMetadata.javaPackageName
+              version: .javaMetadata.version
         actionDataFilter:
           toStateData: .actionTemplateFetchCIResult
     onErrors:
@@ -143,23 +143,23 @@ states:
             url: >-
               https://github.com/janus-idp/software-templates/tree/main/skeletons/catalog-info
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              imageUrl: imageUrl
-              imageRepository: .imageRepository
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              imageUrl: .ciMethod.imageUrl
+              imageRepository: .ciMethod.imageRepository
               imageBuilder: s2i-go
-              port: .port
-              ci: .ci
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
-              groupId: .groupId
-              artifactId: .artifactId
-              javaPackageName: .javaPackageName
-              version: .version
+              groupId: .javaMetadata.groupId
+              artifactId: .javaMetadata.artifactId
+              javaPackageName: .javaMetadata.javaPackageName
+              version: .javaMetadata.version
         actionDataFilter:
           toStateData: .actionFetchTemplateCatalogInfoResult
     onErrors:
@@ -178,7 +178,7 @@ states:
             allowedHosts:
               - '"github.com"'
             description: Workflow Action
-            repoUrl: '"github.com?owner=" + .orgName + "&repo=" + .repoName'
+            repoUrl: '"github.com?owner=" + .newComponent.orgName + "&repo=" + .newComponent.repoName'
             defaultBranch: main
             gitCommitMessage: Initial commit
             allowAutoMerge: true

--- a/workflows/schemas/ansible-job-template__main-schema.json
+++ b/workflows/schemas/ansible-job-template__main-schema.json
@@ -4,13 +4,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "ansible-job-template__ref-schema__GitHub_Repository_Info.json": {
+    "repositoryInfo": {
       "$ref": "ansible-job-template__ref-schema__GitHub_Repository_Info.json",
       "type": "object"
     },
-    "ansible-job-template__ref-schema__Ansible_Job_Definition.json": {
+    "ansibleJobDefinition": {
       "$ref": "ansible-job-template__ref-schema__Ansible_Job_Definition.json",
       "type": "object"
     }
-  }
+  },
+  "required": ["repositoryInfo", "ansibleJobDefinition"]
 }

--- a/workflows/schemas/go-backend__main-schema.json
+++ b/workflows/schemas/go-backend__main-schema.json
@@ -4,13 +4,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "go-backend__ref-schema__New_Component.json": {
+    "newComponent": {
       "$ref": "go-backend__ref-schema__New_Component.json",
       "type": "object"
     },
-    "go-backend__ref-schema__CI_Method.json": {
+    "ciMethod": {
       "$ref": "go-backend__ref-schema__CI_Method.json",
       "type": "object"
     }
-  }
+  },
+  "required": ["newComponent", "ciMethod"]
 }

--- a/workflows/schemas/nodejs-backend__main-schema.json
+++ b/workflows/schemas/nodejs-backend__main-schema.json
@@ -4,13 +4,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "nodejs-backend__ref-schema__New_Component.json": {
+    "newComponent": {
       "$ref": "nodejs-backend__ref-schema__New_Component.json",
       "type": "object"
     },
-    "nodejs-backend__ref-schema__CI_Method.json": {
+    "ciMethod": {
       "$ref": "nodejs-backend__ref-schema__CI_Method.json",
       "type": "object"
     }
-  }
+  },
+  "required": ["newComponent", "ciMethod"]
 }

--- a/workflows/schemas/quarkus-backend__main-schema.json
+++ b/workflows/schemas/quarkus-backend__main-schema.json
@@ -4,17 +4,18 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "quarkus-backend__ref-schema__New_Component.json": {
+    "newComponent": {
       "$ref": "quarkus-backend__ref-schema__New_Component.json",
       "type": "object"
     },
-    "quarkus-backend__ref-schema__Java_Metadata.json": {
+    "javaMetadata": {
       "$ref": "quarkus-backend__ref-schema__Java_Metadata.json",
       "type": "object"
     },
-    "quarkus-backend__ref-schema__CI_Method.json": {
+    "ciMethod": {
       "$ref": "quarkus-backend__ref-schema__CI_Method.json",
       "type": "object"
     }
-  }
+  },
+  "required": ["newComponent", "javaMetadata", "ciMethod"]
 }

--- a/workflows/schemas/spring-boot-backend__main-schema.json
+++ b/workflows/schemas/spring-boot-backend__main-schema.json
@@ -4,17 +4,18 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "spring-boot-backend__ref-schema__New_Component.json": {
+    "newComponent": {
       "$ref": "spring-boot-backend__ref-schema__New_Component.json",
       "type": "object"
     },
-    "spring-boot-backend__ref-schema__Java_Metadata.json": {
+    "javaMetadata": {
       "$ref": "spring-boot-backend__ref-schema__Java_Metadata.json",
       "type": "object"
     },
-    "spring-boot-backend__ref-schema__CI_Method.json": {
+    "ciMethod": {
       "$ref": "spring-boot-backend__ref-schema__CI_Method.json",
       "type": "object"
     }
-  }
+  },
+  "required": ["newComponent", "javaMetadata", "ciMethod"]
 }

--- a/workflows/schemas/yamlgreet__main-schema.json
+++ b/workflows/schemas/yamlgreet__main-schema.json
@@ -7,6 +7,7 @@
     "language": {
       "title": "Language",
       "description": "Language to greet",
+      "type": "string",
       "enum": ["English", "Spanish"],
       "default": "English"
     },

--- a/workflows/spring-boot-backend.sw.yaml
+++ b/workflows/spring-boot-backend.sw.yaml
@@ -32,20 +32,20 @@ states:
             url: >-
               https://github.com/janus-idp/software-templates/tree/main/templates/github/spring-boot-backend/skeleton
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
-              groupId: .groupId
-              artifactId: .artifactId
-              javaPackageName: .javaPackageName
-              version: .version
+              groupId: .javaMetadata.groupId
+              artifactId: .javaMetadata.artifactId
+              javaPackageName: .javaMetadata.javaPackageName
+              version: .javaMetadata.version
         actionDataFilter:
           toStateData: .actionFetchTemplateSourceCodeResult
     onErrors:
@@ -56,9 +56,9 @@ states:
   - name: Generating the CI Component
     type: switch
     dataConditions:
-      - condition: ${ .ci == "github" }
+      - condition: ${ .ciMethod.ci == "github" }
         transition: Generating the CI Component - GitHub
-      - condition: ${ .ci == "tekton" }
+      - condition: ${ .ciMethod.ci == "tekton" }
         transition: Generating the CI Component - Tekton
     defaultCondition:
       transition: Generating the CI Component - GitHub
@@ -75,20 +75,20 @@ states:
             copyWithoutTemplating:
               - '".github/workflows/"'
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              port: .port
-              ci: .ci
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
-              groupId: .groupId
-              artifactId: .artifactId
-              javaPackageName: .javaPackageName
-              version: .version
+              groupId: .javaMetadata.groupId
+              artifactId: .javaMetadata.artifactId
+              javaPackageName: .javaMetadata.javaPackageName
+              version: .javaMetadata.version
         actionDataFilter:
           toStateData: .actionTemplateFetchCIResult
     onErrors:
@@ -109,23 +109,23 @@ states:
             copyWithoutTemplating:
               - '".github/workflows/"'
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
               imageUrl: .imageUrl
               imageRepository: .imageRepository
-              imageBuilder: s2i-java
-              port: .port
-              ci: .ci
+              imageBuilder: s2i-go
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
-              groupId: .groupId
-              artifactId: .artifactId
-              javaPackageName: .javaPackageName
-              version: .version
+              groupId: .javaMetadata.groupId
+              artifactId: .javaMetadata.artifactId
+              javaPackageName: .javaMetadata.javaPackageName
+              version: .javaMetadata.version
         actionDataFilter:
           toStateData: .actionTemplateFetchCIResult
     onErrors:
@@ -143,23 +143,23 @@ states:
             url: >-
               https://github.com/janus-idp/software-templates/tree/main/skeletons/catalog-info
             values:
-              orgName: .orgName
-              repoName: .repoName
-              owner: .owner
-              system: .system
+              orgName: .newComponent.orgName
+              repoName: .newComponent.repoName
+              owner: .newComponent.owner
+              system: .newComponent.system
               applicationType: api
-              description: .description
-              namespace: .namespace
-              imageUrl: imageUrl
-              imageRepository: .imageRepository
+              description: .newComponent.description
+              namespace: .ciMethod.namespace
+              imageUrl: .ciMethod.imageUrl
+              imageRepository: .ciMethod.imageRepository
               imageBuilder: s2i-go
-              port: .port
-              ci: .ci
+              port: .newComponent.port
+              ci: .ciMethod.ci
               sourceControl: github.com
-              groupId: .groupId
-              artifactId: .artifactId
-              javaPackageName: .javaPackageName
-              version: .version
+              groupId: .javaMetadata.groupId
+              artifactId: .javaMetadata.artifactId
+              javaPackageName: .javaMetadata.javaPackageName
+              version: .javaMetadata.version
         actionDataFilter:
           toStateData: .actionFetchTemplateCatalogInfoResult
     onErrors:
@@ -178,7 +178,7 @@ states:
             allowedHosts:
               - '"github.com"'
             description: Workflow Action
-            repoUrl: '"github.com?owner=" + .orgName + "&repo=" + .repoName'
+            repoUrl: '"github.com?owner=" + .newComponent.orgName + "&repo=" + .newComponent.repoName'
             defaultBranch: main
             gitCommitMessage: Initial commit
             allowAutoMerge: true


### PR DESCRIPTION
To enable server-side validation for JSON Schemas that include references to sub-schemas, we need to add all sub-schema keys to the `required` array in the "main" schema. Once we do it, we need to refer to each variable as `.<subSchemaKey>.property` in the workflow definition, otherwise validation will fail because it needs to follow the main schema structure (e.g. `.<subSchemaKey>.githubOrg` in favor of `.githubOrg`). That's precisely what this PR is about.

I also renamed all sub-schema keys to something better to be used in the workflow definition.
So, instead of `ansible-job-template__ref-schema__GitHub_Repository_Info.json`, this key was renamed to `repositoryInfo`. This way, we can reference each variable using `.repositoryInfo.githubOrg`, for instance.

Before merging this PR, we need some changes in the Orchestrator Plugin. So, I'm keeping it a draft while the required changes are not done.

Same changes done in https://github.com/caponetto/orchestrator-workflows/pull/18